### PR TITLE
Set timezone to America/Bogota in docker-compose environment

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -20,6 +20,8 @@ services:
     restart: always
     networks:
       - red-gane-int
+    environment:
+      - TZ=America/Bogota
 
 networks:
   red-gane-int:


### PR DESCRIPTION
se agrega variable de entorno para que contenedor tenga la zona horaria de colombia bogota, revisar si este cambios soluciona error fechas en production